### PR TITLE
remove all_vars from argument of convert_all and decode_solution

### DIFF
--- a/tests/test_binpacking.py
+++ b/tests/test_binpacking.py
@@ -117,9 +117,9 @@ def test_decode_solution():
     problem += x[0] + x[1]
     problem += x[0] + x[1] >= 2
 
-    c, integrality, constraints, bounds = convert_all(problem, [x])
+    c, integrality, constraints, bounds = convert_all(problem)
     result = milp(c, integrality=integrality, constraints=constraints, bounds=bounds)
-    decode_solution(result, problem, [x])
+    decode_solution(result, problem)
     assert x[0].value() == result.x[0]
     assert x[1].value() == result.x[1]
 
@@ -145,7 +145,7 @@ def test_binpack2mat():
     # convert to matrix formulation
     obj_val_pulp = bpp.problem.objective.value()
     all_vars = [bpp.x, bpp.y]
-    vars_dict, varnames = get_vars(all_vars)
+    vars_dict, varnames = get_vars(bpp.problem)
     const_mat, const_lb, const_ub = get_constraint_matrix(bpp.problem, vars_dict)
     obj_arr = get_objective_array(bpp.problem, vars_dict)
     integrality, lbounds, ubounds = get_bounds(vars_dict)
@@ -153,7 +153,7 @@ def test_binpack2mat():
     bounds = Bounds(lbounds, ubounds)
     consts = LinearConstraint(const_mat, const_lb, const_ub)
     result = milp(c=obj_arr, constraints=consts, integrality=integrality, bounds=bounds)
-    decode_solution(result, bpp.problem, all_vars)
+    decode_solution(result, bpp.problem)
     assert result.status == 0
     assert result.fun == obj_val_pulp
 
@@ -167,7 +167,7 @@ def test_maximize():
     # convert to matrix formulation
     obj_val_pulp = bpp.problem.objective.value()
     all_vars = [bpp.x, bpp.y]
-    vars_dict, varnames = get_vars(all_vars)
+    vars_dict, varnames = get_vars(bpp.problem)
     const_mat, const_lb, const_ub = get_constraint_matrix(bpp.problem, vars_dict)
     obj_arr = get_objective_array(bpp.problem, vars_dict)
     integrality, lbounds, ubounds = get_bounds(vars_dict)
@@ -175,6 +175,6 @@ def test_maximize():
     bounds = Bounds(lbounds, ubounds)
     consts = LinearConstraint(const_mat, const_lb, const_ub)
     result = milp(c=obj_arr, constraints=consts, integrality=integrality, bounds=bounds)
-    decode_solution(result, bpp.problem, all_vars)
+    decode_solution(result, bpp.problem)
     assert result.status == 0
     assert result.fun == -obj_val_pulp


### PR DESCRIPTION
As per title, this change removed all_vars from the argument of convert_all and decode_solution functions.
I think that it is more useful for users not to have to provide all_vars, a list of dict variables, to these functions.

I have tested this pull request by pytest and the following code.

```python
import pulp as pl
import numpy as np

# Variables * must be defined as dictionaries
x = {
    i: pl.LpVariable("x_{}".format(i), cat=pl.LpInteger)
    for i in range(2)
}

problem = pl.LpProblem()
problem += x[0] + x[1]
problem += x[0] + x[1] >= 2

import pulp2mat
from scipy.optimize import milp
c, integrality, constraints, bounds = pulp2mat.convert_all(problem)
result = milp(c, integrality=integrality, constraints=constraints, bounds=bounds)

pulp2mat.decode_solution(result, problem)
print("x[0] =", x[0].value())
print("x[1] =", x[1].value())
```

